### PR TITLE
Implement onepager with charts and dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Retailstars Onepager</title>
   </head>
-  <body class="min-h-screen">
+  <body class="min-h-screen bg-white dark:bg-gray-900">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,13 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0",
+    "react-icons": "^4.11.0",
+    "framer-motion": "^10.12.16",
+    "react-hook-form": "^7.45.2",
+    "react-datepicker": "^4.24.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,39 +1,46 @@
 import Hero from './components/Hero';
-import DashboardModules from './components/DashboardModules';
-import Integrations from './components/Integrations';
-import Support from './components/Support';
-import UserManagement from './components/UserManagement';
-import InfoSection from './components/InfoSection';
+import Features from './components/Features';
+import DataVisualization from './components/DataVisualization';
+import UseCaseBanner from './components/UseCaseBanner';
+import ModulesAccordion from './components/ModulesAccordion';
+import ProductCards from './components/ProductCards';
 import ContactVacancies from './components/ContactVacancies';
 
 function App() {
   return (
     <div className="flex flex-col min-h-screen font-sans">
-      <nav className="bg-gray-100 p-4 shadow fixed top-0 left-0 right-0 flex justify-between">
-        <div className="text-xl font-bold">Retailstars</div>
-        <div className="space-x-4">
-          <a href="#hero" className="text-gray-700 hover:text-gray-900">Home</a>
-          <a href="#dashboard" className="text-gray-700 hover:text-gray-900">Dashboard</a>
-          <a href="#integraties" className="text-gray-700 hover:text-gray-900">Integraties</a>
-          <a href="#support" className="text-gray-700 hover:text-gray-900">Support</a>
-          <a href="#users" className="text-gray-700 hover:text-gray-900">Users</a>
-          <a href="#info" className="text-gray-700 hover:text-gray-900">Info</a>
-          <a href="#contact" className="text-gray-700 hover:text-gray-900">Contact</a>
+      <nav className="bg-white/80 backdrop-blur p-4 shadow fixed top-0 left-0 right-0 flex justify-between z-10">
+        <div className="text-xl font-bold text-primary">Retailstars</div>
+        <div className="space-x-4 hidden md:block">
+          <a href="#hero" className="text-primary hover:underline">Home</a>
+          <a href="#features" className="text-primary hover:underline">Features</a>
+          <a href="#usecase" className="text-primary hover:underline">Use Case</a>
+          <a href="#modules" className="text-primary hover:underline">Modules</a>
+          <a href="#products" className="text-primary hover:underline">Producten</a>
+          <a href="#contact" className="text-primary hover:underline">Contact</a>
         </div>
+        {/* Simple dark mode toggle */}
+        <button
+          onClick={() => document.documentElement.classList.toggle('dark')}
+          className="ml-4 text-primary border rounded px-2 py-1"
+        >
+          Toggle
+        </button>
       </nav>
 
       <main className="mt-16">
         <Hero />
-        <DashboardModules />
-        <Integrations />
-        <Support />
-        <UserManagement />
-        <InfoSection />
+        <Features />
+        <DataVisualization />
+        <UseCaseBanner />
+        <ModulesAccordion />
+        <ProductCards />
         <ContactVacancies />
       </main>
 
       <footer className="bg-gray-100 text-gray-500 text-sm text-center p-4">
-        © 2025 Retailstars
+        <p>Europark 24, 4904 SX Oosterhout</p>
+        <p>+31 (0)85 744 1415 · info@retailstars.nl · KvK 61807893</p>
       </footer>
     </div>
   );

--- a/src/components/ContactVacancies.jsx
+++ b/src/components/ContactVacancies.jsx
@@ -1,4 +1,7 @@
 import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
 
 const vacancies = [
   { id: 1, title: 'Frontend Developer', location: 'Remote' },
@@ -6,51 +9,55 @@ const vacancies = [
 ];
 
 function ContactVacancies() {
-  const [form, setForm] = useState({ name: '', email: '', message: '' });
+  const { register, handleSubmit, reset } = useForm();
+  const [callBack, setCallBack] = useState(false);
+  const [date, setDate] = useState(null);
 
-  const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
-  };
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
+  const onSubmit = (data) => {
     // TODO: replace with real submit via REST API
-    alert(`Bedankt ${form.name}, we nemen contact op!`);
+    alert(`Bedankt ${data.name}, we nemen contact op!`);
+    reset();
+    setDate(null);
   };
 
   return (
     <section id="contact" className="py-16 bg-gray-50">
-      <h2 className="text-3xl font-semibold text-center mb-8 text-blue-800">Contact &amp; Vacatures</h2>
+      <h2 className="text-3xl font-semibold text-center mb-8 text-primary">Contact &amp; Vacatures</h2>
       <div className="max-w-4xl mx-auto grid md:grid-cols-2 gap-8">
-        <form onSubmit={handleSubmit} className="space-y-4 border rounded p-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 border rounded p-4">
           <input
             type="text"
-            name="name"
             placeholder="Naam"
-            value={form.name}
-            onChange={handleChange}
+            {...register('name', { required: true })}
             className="w-full border p-2 rounded"
-            required
           />
           <input
             type="email"
-            name="email"
             placeholder="Email"
-            value={form.email}
-            onChange={handleChange}
+            {...register('email', { required: true })}
             className="w-full border p-2 rounded"
-            required
           />
           <textarea
-            name="message"
             placeholder="Bericht"
-            value={form.message}
-            onChange={handleChange}
+            {...register('message', { required: true })}
             className="w-full border p-2 rounded"
             rows="4"
-            required
           />
-          <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Verstuur</button>
+          <div className="flex items-center space-x-2">
+            <input type="checkbox" id="callback" onChange={() => setCallBack(!callBack)} />
+            <label htmlFor="callback" className="text-sm">Bel mij terug</label>
+          </div>
+          {callBack && (
+            <DatePicker
+              selected={date}
+              onChange={setDate}
+              showTimeSelect
+              dateFormat="Pp"
+              className="w-full border p-2 rounded"
+              placeholderText="Kies datum en tijd"
+            />
+          )}
+          <button type="submit" className="bg-secondary text-white px-4 py-2 rounded hover:bg-orange-600">Verstuur</button>
         </form>
         <div>
           <h3 className="text-xl font-medium mb-4">Vacatures</h3>

--- a/src/components/DataVisualization.jsx
+++ b/src/components/DataVisualization.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+const data = {
+  labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+  datasets: [
+    {
+      label: 'Orders',
+      data: [10, 20, 15, 25, 30, 28],
+      borderColor: '#F48323',
+      backgroundColor: 'rgba(244,131,35,0.4)',
+    },
+    {
+      label: 'Voorraad',
+      data: [40, 35, 30, 28, 20, 15],
+      borderColor: '#014961',
+      backgroundColor: 'rgba(1,73,97,0.4)',
+    },
+  ],
+};
+
+function DataVisualization() {
+  return (
+    <section id="chart" className="py-16 bg-gray-50">
+      <h2 className="text-3xl font-semibold text-center mb-8 text-primary">
+        Realtime orders vs voorraad
+      </h2>
+      <div className="max-w-3xl mx-auto bg-white p-4 rounded shadow">
+        <Line data={data} />
+      </div>
+    </section>
+  );
+}
+
+export default DataVisualization;

--- a/src/components/Features.jsx
+++ b/src/components/Features.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { FaChartLine, FaPlug, FaLifeRing, FaUsers } from 'react-icons/fa';
+
+const features = [
+  {
+    icon: FaChartLine,
+    title: 'Analytics',
+    desc: 'Realtime inzichten in je data',
+  },
+  {
+    icon: FaPlug,
+    title: 'Integraties',
+    desc: 'Koppel eenvoudig met je platformen',
+  },
+  {
+    icon: FaLifeRing,
+    title: 'Support',
+    desc: '24/7 service desk beschikbaar',
+  },
+  {
+    icon: FaUsers,
+    title: 'Users',
+    desc: 'Rolgebaseerd beheer',
+  },
+];
+
+function Features() {
+  return (
+    <section id="features" className="py-16 bg-white">
+      <h2 className="text-3xl font-semibold text-center mb-8 text-primary">
+        Features
+      </h2>
+      <div className="max-w-5xl mx-auto grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        {features.map(({ icon: Icon, title, desc }) => (
+          <div
+            key={title}
+            className="p-6 border rounded shadow-sm hover:shadow-md transition-shadow"
+          >
+            <Icon className="text-secondary text-4xl mb-2" />
+            <h3 className="font-medium mb-1">{title}</h3>
+            <p className="text-sm text-gray-600">{desc}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default Features;

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -2,18 +2,31 @@ import React from 'react';
 
 function Hero() {
   return (
-    <section id="hero" className="bg-gray-50 pt-20 pb-32 text-center">
-      <h1 className="text-4xl md:text-5xl font-bold mb-4 text-blue-800">Retailstars Dashboard</h1>
-      <p className="max-w-xl mx-auto text-gray-700 mb-6">
-        One platform voor omnichannel inzichten, integratiebeheer en service management.
+    <section
+      id="hero"
+      className="pt-32 pb-40 text-center bg-gradient-to-br from-primary to-secondary text-white"
+    >
+      <h1 className="text-4xl md:text-5xl font-bold mb-4">
+        Boost je retailprestaties met Retailstars
+      </h1>
+      <p className="max-w-xl mx-auto mb-6">
+        Data-gedreven marketing & voorraadoptimalisatie in één platform.
       </p>
-      {/* TODO: replace alert with actual demo booking hook */}
-      <button
-        onClick={() => alert('Plan een demo - koppel je eigen handler')}
-        className="bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700"
-      >
-        Plan een demo
-      </button>
+      <div className="space-x-4">
+        {/* TODO: replace alert with actual demo booking hook */}
+        <button
+          onClick={() => alert('Plan een gratis demo')}
+          className="bg-secondary text-white px-6 py-3 rounded hover:bg-orange-600"
+        >
+          Plan een gratis demo
+        </button>
+        <a
+          href="#features"
+          className="border border-white px-6 py-3 rounded hover:bg-white hover:text-primary"
+        >
+          Bekijk features
+        </a>
+      </div>
     </section>
   );
 }

--- a/src/components/ModulesAccordion.jsx
+++ b/src/components/ModulesAccordion.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+const modules = [
+  {
+    title: 'Dashboard',
+    content: 'Overzicht van alle prestaties in één oogopslag.',
+  },
+  {
+    title: 'Integraties',
+    content: 'Koppelingen met toonaangevende platformen.',
+  },
+  {
+    title: 'Support',
+    content: 'Directe toegang tot onze servicedesk.',
+  },
+  {
+    title: 'User Management',
+    content: 'Beheer van rollen en rechten.',
+  },
+];
+
+function ModulesAccordion() {
+  const [open, setOpen] = useState(null);
+
+  const toggle = (idx) => {
+    setOpen(open === idx ? null : idx);
+  };
+
+  return (
+    <section id="modules" className="py-16 bg-white">
+      <h2 className="text-3xl font-semibold text-center mb-8 text-primary">
+        Modules
+      </h2>
+      <div className="max-w-3xl mx-auto">
+        {modules.map((m, idx) => (
+          <div key={m.title} className="border-b">
+            <button
+              onClick={() => toggle(idx)}
+              className="w-full text-left p-4 flex justify-between items-center"
+            >
+              <span>{m.title}</span>
+              <span>{open === idx ? '-' : '+'}</span>
+            </button>
+            <AnimatePresence initial={false}>
+              {open === idx && (
+                <motion.div
+                  key="content"
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: 'auto', opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  className="overflow-hidden px-4 pb-4 text-gray-600"
+                >
+                  {m.content}
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default ModulesAccordion;

--- a/src/components/ProductCards.jsx
+++ b/src/components/ProductCards.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+const products = [
+  { title: 'Novulo', usps: ['Snel deployen', 'Modulair'], link: '#' },
+  { title: 'RDS', usps: ['Realtime data', 'Schaalbaar'], link: '#' },
+  { title: 'Channel Engine', usps: ['Marketplace integratie'], link: '#' },
+  { title: 'Dovetail', usps: ['Project management'], link: '#' },
+  { title: 'Magento', usps: ['Populair e-commerce platform'], link: '#' },
+  { title: 'Adyen', usps: ['Betrouwbare payments'], link: '#' },
+];
+
+function ProductCards() {
+  return (
+    <section id="products" className="py-16 bg-gray-50">
+      <h2 className="text-3xl font-semibold text-center mb-8 text-primary">
+        Producten
+      </h2>
+      <div className="max-w-6xl mx-auto grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {products.map((p) => (
+          <div key={p.title} className="border rounded p-4 bg-white shadow-sm">
+            <h3 className="font-medium mb-2 text-secondary">{p.title}</h3>
+            <ul className="text-sm text-gray-600 mb-2 list-disc list-inside">
+              {p.usps.map((u) => (
+                <li key={u}>{u}</li>
+              ))}
+            </ul>
+            <a href={p.link} className="text-primary underline text-sm">
+              Lees meer
+            </a>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default ProductCards;

--- a/src/components/UseCaseBanner.jsx
+++ b/src/components/UseCaseBanner.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+function UseCaseBanner() {
+  return (
+    <section className="bg-secondary text-white py-12 text-center">
+      <blockquote className="text-xl font-semibold">
+        +25% omzetgroei in 3 maanden bij Klant X
+      </blockquote>
+    </section>
+  );
+}
+
+export default UseCaseBanner;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply text-gray-800 bg-white dark:bg-gray-900 dark:text-gray-100;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,9 +1,11 @@
 module.exports = {
   content: ['./index.html', './src/**/*.{js,jsx}'],
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {
-        brand: '#0055A4',
+        primary: '#014961',
+        secondary: '#F48323',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add dependencies for icons, charts, datepicker, motion and forms
- enable dark mode and brand colors in Tailwind
- implement a gradient hero banner with CTA buttons
- create feature grid, chart section, use case banner and modules accordion
- add product card grid and improved contact form with callback option
- wire new sections in App and update footer info

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849cd19d2948325ae282363c21fd95a