### PR TITLE
Add mission and services sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+/dist
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "start": "vite",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,47 +1,29 @@
+import Navbar from './components/Navbar';
 import Hero from './components/Hero';
-import Features from './components/Features';
+import Mission from './components/Mission';
+import Services from './components/Services';
 import DataVisualization from './components/DataVisualization';
-import UseCaseBanner from './components/UseCaseBanner';
-import ModulesAccordion from './components/ModulesAccordion';
-import ProductCards from './components/ProductCards';
+import IntegrationsList from './components/IntegrationsList';
+import Products from './components/Products';
+import CallBanner from './components/CallBanner';
 import ContactVacancies from './components/ContactVacancies';
+import Footer from './components/Footer';
 
 function App() {
   return (
     <div className="flex flex-col min-h-screen font-sans">
-      <nav className="bg-white/80 backdrop-blur p-4 shadow fixed top-0 left-0 right-0 flex justify-between z-10">
-        <div className="text-xl font-bold text-primary">Retailstars</div>
-        <div className="space-x-4 hidden md:block">
-          <a href="#hero" className="text-primary hover:underline">Home</a>
-          <a href="#features" className="text-primary hover:underline">Features</a>
-          <a href="#usecase" className="text-primary hover:underline">Use Case</a>
-          <a href="#modules" className="text-primary hover:underline">Modules</a>
-          <a href="#products" className="text-primary hover:underline">Producten</a>
-          <a href="#contact" className="text-primary hover:underline">Contact</a>
-        </div>
-        {/* Simple dark mode toggle */}
-        <button
-          onClick={() => document.documentElement.classList.toggle('dark')}
-          className="ml-4 text-primary border rounded px-2 py-1"
-        >
-          Toggle
-        </button>
-      </nav>
-
+      <Navbar />
       <main className="mt-16">
         <Hero />
-        <Features />
+        <Mission />
+        <Services />
         <DataVisualization />
-        <UseCaseBanner />
-        <ModulesAccordion />
-        <ProductCards />
+        <IntegrationsList />
+        <Products />
+        <CallBanner />
         <ContactVacancies />
       </main>
-
-      <footer className="bg-gray-100 text-gray-500 text-sm text-center p-4">
-        <p>Europark 24, 4904 SX Oosterhout</p>
-        <p>+31 (0)85 744 1415 · info@retailstars.nl · KvK 61807893</p>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/src/components/CallBanner.jsx
+++ b/src/components/CallBanner.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { FaPhone } from 'react-icons/fa';
+
+function CallBanner() {
+  return (
+    <section className="bg-secondary text-white py-12 text-center" id="contact">
+      <h2 className="text-2xl font-semibold mb-4">Direct contact?</h2>
+      <button
+        onClick={() => alert('We bellen u zo snel mogelijk terug')}
+        className="bg-white text-secondary px-6 py-3 rounded font-medium mb-4"
+      >
+        Bel mij
+      </button>
+      <p>+31 (0)85 744 1415 | +44 330 808 1832 | info@retailstars.nl</p>
+    </section>
+  );
+}
+
+export default CallBanner;

--- a/src/components/ContactVacancies.jsx
+++ b/src/components/ContactVacancies.jsx
@@ -21,7 +21,7 @@ function ContactVacancies() {
   };
 
   return (
-    <section id="contact" className="py-16 bg-gray-50">
+    <section id="vacatures" className="py-16 bg-gray-50">
       <h2 className="text-3xl font-semibold text-center mb-8 text-primary">Contact &amp; Vacatures</h2>
       <div className="max-w-4xl mx-auto grid md:grid-cols-2 gap-8">
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 border rounded p-4">

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+function Footer() {
+  return (
+    <footer className="bg-gray-100 text-gray-600 text-sm text-center p-4" id="contact">
+      <p>Europark 24, 4904 SX Oosterhout</p>
+      <p>BTW: NL-85.44.97.043.B01</p>
+      <p className="space-x-2">
+        <a href="#" className="underline">Privacy</a>
+        <a href="#" className="underline">Cookies</a>
+        <a href="https://www.linkedin.com/company/retailstars" className="underline">LinkedIn</a>
+      </p>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/components/IntegrationsList.jsx
+++ b/src/components/IntegrationsList.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { FaPlug } from 'react-icons/fa';
+
+// TODO: replace with fetch to integrations API
+const integrations = [
+  'Adyen','AfterPay','Akineo','Alipay','Asperion','AuroraCommerce','BazaarVoice','BeautySuccess','BusinessCentral','CCV','Centric','ChainBalance','ChannelEngine','DieboldNixdorf','EcoVoucher','Eloqua','EuroPass','Experian','FashionCheque','GoogleAnalytics','Ingenico','Itim','Logistex','Magento','Mendix','NCR','NiceLabel','Nshift','Responsys','Salesforce','SAP','ScanCoin','SharePoint','SQLServer','Talend','TCS','TrustPilot','Tyro','WeChat','WorldLine'
+];
+
+function IntegrationsList() {
+  return (
+    <section id="integraties" className="py-16 bg-white">
+      <h2 className="text-3xl font-semibold text-center mb-8 text-primary">Integraties</h2>
+      <div className="max-w-6xl mx-auto grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4 text-center">
+        {integrations.map((name) => (
+          <div key={name} className="border rounded p-4 flex flex-col items-center bg-gray-50">
+            <FaPlug className="text-secondary mb-2" />
+            <span className="text-sm">{name}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default IntegrationsList;

--- a/src/components/Mission.jsx
+++ b/src/components/Mission.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+function Mission() {
+  return (
+    <section id="mission" className="py-16 bg-white">
+      <h2 className="text-3xl font-semibold text-center mb-6 text-primary">Onze missie</h2>
+      <p className="max-w-3xl mx-auto text-center mb-4">
+        Het vergroten van activiteit op al uw verkoopkanalen, op ieder moment en vanuit elke locatie waardoor u extra verkoopkansen creëert en deze maximaal kunt benutten.
+      </p>
+      <ul className="max-w-xl mx-auto list-disc list-inside space-y-2 text-gray-700">
+        <li>Laat online en offline grenzen verdwijnen door omnichannel-services.</li>
+        <li>Verbeter uw dienstverlening door winkelmedewerkers te ondersteunen met digitale oplossingen.</li>
+        <li>Verkrijg betrouwbare voorraadinzichten vanuit iedere locatie.</li>
+        <li>Adopteer flexibele technologie om snel in te spelen op veranderingen.</li>
+      </ul>
+    </section>
+  );
+}
+
+export default Mission;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { FaBars } from 'react-icons/fa';
+
+function Navbar() {
+  const [open, setOpen] = useState(false);
+  const toggle = () => setOpen(!open);
+
+  const links = [
+    { href: '#hero', label: 'Home' },
+    { href: '#mission', label: 'Over ons' },
+    { href: '#vacatures', label: 'Vacatures' },
+    { href: '#consultancy', label: 'Business Consultancy' },
+    { href: '#services', label: 'Diensten' },
+    { href: '#products', label: 'Producten' },
+    { href: '#partnerships', label: 'Partnerships' },
+    { href: '#servicedesk', label: 'Servicedesk' },
+    { href: '#contact', label: 'Contact' },
+  ];
+
+  return (
+    <nav className="bg-white/80 backdrop-blur fixed top-0 inset-x-0 z-10 shadow">
+      <div className="max-w-7xl mx-auto flex items-center justify-between p-4">
+        <div className="text-xl font-bold text-primary">Retailstars</div>
+        <button className="md:hidden" onClick={toggle} aria-label="Menu">
+          <FaBars />
+        </button>
+        <div className={`flex-col md:flex-row md:flex ${open ? 'flex' : 'hidden'} md:space-x-4 text-sm md:text-base`}>
+          {links.map((l) => (
+            <a
+              key={l.label}
+              href={l.href}
+              className="block px-3 py-2 text-primary hover:underline"
+              onClick={() => setOpen(false)}
+            >
+              {l.label}
+            </a>
+          ))}
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+export default Navbar;

--- a/src/components/Products.jsx
+++ b/src/components/Products.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { FaShoppingCart, FaChartLine, FaPlug } from 'react-icons/fa';
+
+const products = [
+  { icon: FaShoppingCart, title: 'Commerce', link: '#' },
+  { icon: FaChartLine, title: 'Data & Analytics', link: '#' },
+  { icon: FaPlug, title: 'Integrations', link: '#' },
+];
+
+function Products() {
+  return (
+    <section id="products" className="py-16 bg-gray-50">
+      <h2 className="text-3xl font-semibold text-center mb-8 text-primary">Producten</h2>
+      <div className="max-w-4xl mx-auto grid sm:grid-cols-2 md:grid-cols-3 gap-6">
+        {products.map(({ icon: Icon, title, link }) => (
+          <div key={title} className="border rounded p-6 bg-white text-center shadow-sm">
+            <Icon className="text-secondary text-4xl mb-2 mx-auto" />
+            <h3 className="font-medium mb-2">{title}</h3>
+            <a href={link} className="text-primary underline text-sm">Lees meer</a>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default Products;

--- a/src/components/RequireRole.jsx
+++ b/src/components/RequireRole.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function RequireRole({ role, allowed, children }) {
+  // TODO: replace with real RBAC check using auth context
+  if (!allowed.includes(role)) {
+    return null;
+  }
+  return <>{children}</>;
+}
+
+export default RequireRole;

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FaHandsHelping, FaTasks, FaCogs, FaLifeRing, FaChartBar, FaCode } from 'react-icons/fa';
+
+const services = [
+  { icon: FaHandsHelping, title: 'Consultancy', link: '#' },
+  { icon: FaTasks, title: 'Project management', link: '#' },
+  { icon: FaCogs, title: 'Implementation', link: '#' },
+  { icon: FaLifeRing, title: 'Support', link: '#' },
+  { icon: FaChartBar, title: 'Monitoring', link: '#' },
+  { icon: FaCode, title: 'Development', link: '#' },
+];
+
+function Services() {
+  return (
+    <section id="services" className="py-16 bg-gray-50">
+      <h2 className="text-3xl font-semibold text-center mb-8 text-primary">Diensten</h2>
+      {/* TODO: replace with data from headless CMS */}
+      <div className="max-w-6xl mx-auto grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {services.map(({ icon: Icon, title, link }) => (
+          <div key={title} className="border rounded p-6 bg-white text-center shadow-sm">
+            <Icon className="text-secondary text-4xl mb-2 mx-auto" />
+            <h3 className="font-medium mb-2">{title}</h3>
+            <a href={link} className="text-primary underline text-sm">Lees meer</a>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default Services;


### PR DESCRIPTION
## Summary
- add navbar with full menu
- implement mission, services, integrations and product sections
- add call-to-action banner and footer info
- include RBAC wrapper example
- update App.js and npm scripts

## Testing
- `npm install`
- `npm start`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684aeec993708325987ff1f08cbacd65